### PR TITLE
Add integration test, for real

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test/etc/server/server.properties

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 bin/docker_entrypoint: bin
-	cd go/cmd && go build -o $@
+	cd go/cmd && go build -o ../../$@
 
 bin:
 	mkdir bin
@@ -10,5 +10,7 @@ install:
 docker:
 	docker build --no-cache -t docker_entrypoint .
 
-
-.PHONY: install docker
+clean:
+	rm -rf bin \
+	docker rmi docker_entrypoint:latest
+.PHONY: install docker clean

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # docker_entrypoint
 Templating engine for docker images
 
-Did you have to spend time in finding out to configure a random docker image you just downloaded from Docker registry?  
+Did you have to spend time in finding out to configure a random docker image you just downloaded from Docker registry?
 
-Wouldn't be nice having the same ENV variable be the same across images without the need of replacing entirelly the whole congiguration file or having to dig `docker inspect` and just run an help command?
+Wouldn't be nice having the same ENV variable be the same across images without the need of replacing entirelly the whole configuration file or having to dig `docker inspect` and just run an help command?
 
-Docker entrypoint manages your configuration file templates rendering them from environemnt variables values. 
+Docker entrypoint manages your configuration file templates rendering them from environemnt variables values.
 
-For example, setting Kafka's broker ID would be as simple as setting an environment variable  
+For example, setting Kafka's broker ID would be as simple as setting an environment variable
 `docker run -d --name kafka -e SERVER_PROPERPERTIES_BROKER_ID = 1 mykafka-image`
 
-and gives users an easy way to access all configuration variables with a `help` command:  
+and gives users an easy way to access all configuration variables with a `help` command:
 `docker run -ti --rm mykafka-image --help
 
 ## Dependencies
@@ -23,20 +23,20 @@ to build the base docker_entrypoing image run
 
 ## Usage
 ### Build a configuration file 
-Create a template configuration file `server.properties.template` like the following  
+Create a template configuration file `server.properties.template` like the following
 ```
 server_address={{ .LISTEN_ADDRESS }}
 server_port={{ .LISTEN_PORT }}
 id={{ .ID }}
 ```
 ### Example dockerfile
-The build your image using docker_entrypoint as first stage of a multi-stage build:  
+The build your image using docker_entrypoint as first stage of a multi-stage build:
 ```
 FROM docker_entrypoint as entrypoint
 FROM alpine #OR YOU FAVOURITE BASE IMAGE
 COPY --from=entrypoint /docker_entrypoint /docker_entrypoint
 RUN ...
-MKDIR ...
+RUN mkdir ...
 ENV SERVER_PROPERTIES_LISTEN_ADDRESS="localhost"
 ENV SERVER_PROPERTIES_LISTEN_PORT=8080
 ENV SERVER_PROPERTIES_ID=1

--- a/go/render/templatebuilder_test.go
+++ b/go/render/templatebuilder_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 )
 
-func TestGetEnvironVars(t*testing.T){
+func TestGetEnvironVars(t *testing.T) {
 	_ = os.Setenv("A_B_C", "1")
-	vars := getEnvironVars("A")
-	if vars["B_C"] != "1"{
+	vars, _ := getEnvironVars("A")
+	if vars["B_C"] != "1" {
 		t.Fatalf("%v", vars)
 	}
 }

--- a/go/template/template.go
+++ b/go/template/template.go
@@ -16,7 +16,7 @@ func New(templatePath string, outputPath string, vars map[string]string) Templat
 	t := Template{
 		vars,
 		templatePath,
-		trimExtension(outputPath),
+		outputPath,
 	}
 	return t
 }

--- a/go/template/template_test.go
+++ b/go/template/template_test.go
@@ -23,10 +23,10 @@ func TestMain(m *testing.M) {
 
 func mockFile(content []byte) (string, error) {
 	if tempFile, err := os.Create(tempDir + "/file.temp"); err == nil {
-		defer func (){ _ = tempFile.Close() }()
+		defer func() { _ = tempFile.Close() }()
 		_, err = tempFile.Write(content)
 		return tempFile.Name(), err
-	}else{
+	} else {
 		return "", err
 	}
 }
@@ -42,7 +42,7 @@ func TestTemplate(t *testing.T) {
 		t.Fatal(err)
 	}
 	vars := map[string]string{
-		testVar : testVal,
+		testVar: testVal,
 	}
 	template := New(templatePath, templatePath, vars)
 	if err := template.WriteToPath(resultPath); err != nil {

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -1,6 +1,14 @@
 FROM golang:1.13-alpine
 
 WORKDIR /src/
+COPY ./go /src
 
-CMD ls -l /src/
+WORKDIR go
+RUN go build -o /docker_entrypoint github.com/bejelith/docker_entrypoint/cmd
+
+ENV SERVER_PROPERTIES_LISTEN_ADDRESS="localhost"
+ENV SERVER_PROPERTIES_LISTEN_PORT=8080
+ENV SERVER_PROPERTIES_ID=1
+
+WORKDIR /src/
 CMD go test ./... -v

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,7 +7,10 @@ networks:
 services:
   docker_entrypoint_tests:
     build:
-      context: .
-      dockerfile: ./Dockerfile.test
+      context: ..
+      dockerfile: ./test/Dockerfile.test
+  docker_entrypoint_integration:
+    image: test_docker_entrypoint_tests
+    command: ["/docker_entrypoint","-template","/etc/server/server.properties.template"]
     volumes:
-      - $PWD/../go:/src
+      - $PWD/etc/server:/etc/server

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -11,6 +11,6 @@ services:
       dockerfile: ./test/Dockerfile.test
   docker_entrypoint_integration:
     image: test_docker_entrypoint_tests
-    command: ["/docker_entrypoint","-template","/etc/server/server.properties.template"]
+    command: ["/docker_entrypoint","-template","/etc/server/server.properties.template","/bin/cat","/etc/server/server.properties"]
     volumes:
       - $PWD/etc/server:/etc/server

--- a/test/etc/server/server
+++ b/test/etc/server/server
@@ -1,0 +1,3 @@
+server_address=localhost
+server_port=8080
+id=1

--- a/test/etc/server/server
+++ b/test/etc/server/server
@@ -1,3 +1,0 @@
-server_address=localhost
-server_port=8080
-id=1

--- a/test/etc/server/server.properties.template
+++ b/test/etc/server/server.properties.template
@@ -1,0 +1,3 @@
+server_address={{ .LISTEN_ADDRESS }}
+server_port={{ .LISTEN_PORT }}
+id={{ .ID }}

--- a/vai.sh
+++ b/vai.sh
@@ -4,4 +4,4 @@ set -euxo pipefail
 
 cd ./test
 
-docker-compose up --build --abort-on-container-exit
+docker-compose up --build

--- a/vai.sh
+++ b/vai.sh
@@ -4,4 +4,5 @@ set -euxo pipefail
 
 cd ./test
 
-docker-compose up --build
+docker-compose up --build --abort-on-container-exit --scale=docker_entrypoint_integration=0
+docker-compose up --build --exit-code-from docker_entrypoint_integration --scale docker_entrypoint_tests=0


### PR DESCRIPTION
👻 

@bejelith 

This PR adds other service on the composer `docker_entrypoint_integration` that will invoke the created executable with the following command line:
```
/docker_entrypoint -template /etc/server/server.properties.template /bin/cat /etc/server/server.properties
```
Thus the integration test will fail if the `/etc/server/server.properties` is not generated. The result of `/bin/cat /etc/server/server.properties` can be used for visual inspection of the generated file.

The environment variables for substitution in the template are defined in the Dockerfile for the test image `test/Dockerfile.test`.

`vai.sh` now run two `docker-compose up` commands as I could not find a way to fail the test if one of the services failed, docker-compose as returning exit code 0 if so. The drawback is that the test image is built twice but that can be a good thing as isolated both unit and integration tests.

[Travis is passing](https://travis-ci.org/marcosvm/docker_entrypoint/builds/632414008).